### PR TITLE
Fix a small bug in the regex for comments

### DIFF
--- a/EBNF.tmBundle/Syntaxes/EBNF.tmLanguage
+++ b/EBNF.tmBundle/Syntaxes/EBNF.tmLanguage
@@ -72,7 +72,7 @@
 			<key>begin</key>
 			<string>^\(\*</string>
 			<key>end</key>
-			<string>^\*\)</string>
+			<string>\*\)</string>
 			<key>name</key>
 			<string>comment.block.ebnf</string>
 		</dict>


### PR DESCRIPTION
The end of a comment in an EBNF file was not recognized correctly.
